### PR TITLE
Delete useless parameters in function 'IsWall()'

### DIFF
--- a/raycaster_float.cpp
+++ b/raycaster_float.cpp
@@ -3,7 +3,7 @@
 #include "raycaster_float.h"
 #include <math.h>
 
-bool RayCasterFloat::IsWall(float rayX, float rayY, float rayA)
+bool RayCasterFloat::IsWall(float rayX, float rayY)
 {
     float mapX = 0;
     float mapY = 0;
@@ -93,7 +93,7 @@ float RayCasterFloat::Distance(float playerX,
                 (tileStepY == -1 && (interceptY >= tileY)))) {
             somethingDone = true;
             tileX += tileStepX;
-            if (IsWall(tileX, interceptY, rayA)) {
+            if (IsWall(tileX, interceptY)) {
                 verticalHit = true;
                 rayX = tileX + (tileStepX == -1 ? 1 : 0);
                 rayY = interceptY;
@@ -107,7 +107,7 @@ float RayCasterFloat::Distance(float playerX,
                                 (tileStepX == -1 && (interceptX >= tileX)))) {
             somethingDone = true;
             tileY += tileStepY;
-            if (IsWall(interceptX, tileY, rayA)) {
+            if (IsWall(interceptX, tileY)) {
                 horizontalHit = true;
                 rayX = interceptX;
                 *hitOffset = interceptX;

--- a/raycaster_float.h
+++ b/raycaster_float.h
@@ -26,5 +26,5 @@ private:
                    float rayA,
                    float *hitOffset,
                    int *hitDirection);
-    bool IsWall(float rayX, float rayY, float rayA);
+    bool IsWall(float rayX, float rayY);
 };


### PR DESCRIPTION
There's two commit here which are willing to improve this project:
1. For the function `IsWall()`, it accept an useless parameters, so we should delete it.
2. In floating-point implementation, function `Trace` in `raycaster_float.cpp` will assign `INV_FACTOR / distance`  to an uint8_t variable `screenY`, which may come into an overflow problem, leading to unexpected render. The situation will look like the picture below:

![image](https://user-images.githubusercontent.com/30153990/96966552-93ff3b80-1540-11eb-8c11-ede4073906b7.png)

* To fix the problem, we can just assign `screenY`  to `SCREEN_HEIGHT>>1` for overflow case, since this will meet what the caller of `Trace` expect for. After this change, here's what the effect will look like:

![image](https://user-images.githubusercontent.com/30153990/96966637-b98c4500-1540-11eb-9609-eab2c06132ec.png)

