### PR TITLE
Refactor IsWall into class Map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ OBJS := \
 	raycaster_fixed.o \
 	raycaster_float.o \
 	renderer.o \
-	main.o
+	main.o \
+	map.o
 deps := $(OBJS:%.o=.%.o.d)
 
 %.o: %.cpp

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ OBJS := \
 	raycaster_fixed.o \
 	raycaster_float.o \
 	renderer.o \
-	main.o \
-	map.o
+	map.o \
+	main.o
+
 deps := $(OBJS:%.o=.%.o.d)
 
 %.o: %.cpp

--- a/game.cpp
+++ b/game.cpp
@@ -1,8 +1,8 @@
 #include <cmath>
 #include <cstdlib>
 
+#include "map.h"
 #include "game.h"
-#include "raycaster.h"
 
 void Game::Move(int m, int r, float seconds)
 {
@@ -29,11 +29,14 @@ void Game::Move(int m, int r, float seconds)
     }
 }
 
-Game::Game()
+Game::Game(Map *m)
 {
     playerX = 23.03f;
     playerY = 6.8f;
     playerA = 5.25f;
+    map = m;
 }
 
-Game::~Game() {}
+Game::~Game()
+{
+}

--- a/game.cpp
+++ b/game.cpp
@@ -37,6 +37,4 @@ Game::Game(Map *m)
     map = m;
 }
 
-Game::~Game()
-{
-}
+Game::~Game() {}

--- a/game.cpp
+++ b/game.cpp
@@ -29,12 +29,11 @@ void Game::Move(int m, int r, float seconds)
     }
 }
 
-Game::Game(Map *m)
+Game::Game(const uint8_t *m) : map(m)
 {
     playerX = 23.03f;
     playerY = 6.8f;
     playerA = 5.25f;
-    map = m;
 }
 
 Game::~Game() {}

--- a/game.h
+++ b/game.h
@@ -9,8 +9,8 @@ public:
     void Move(int m, int r, float seconds);
 
     float playerX, playerY, playerA;
-    Map *map;
+    Map map;
 
-    Game(Map *map);
+    Game(const uint8_t *map);
     ~Game();
 };

--- a/game.h
+++ b/game.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "map.h"
 
 class Game
 {
@@ -8,7 +9,8 @@ public:
     void Move(int m, int r, float seconds);
 
     float playerX, playerY, playerA;
+    Map *map;
 
-    Game();
+    Game(Map *map);
     ~Game();
 };

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include "raycaster.h"
 #include "raycaster_fixed.h"
 #include "raycaster_float.h"
+#include "raycaster_data.h"
 #include "renderer.h"
 #include "map.h"
 
@@ -79,8 +80,7 @@ int main(int argc, char *args[])
             printf("Window could not be created! SDL_Error: %s\n",
                    SDL_GetError());
         } else {
-            Map default_map(g_map);
-            Game game(&default_map);
+            Game game(g_map);
             RayCasterFloat floatCaster;
             Renderer floatRenderer(&floatCaster);
             uint32_t floatBuffer[SCREEN_WIDTH * SCREEN_HEIGHT];

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "raycaster_fixed.h"
 #include "raycaster_float.h"
 #include "renderer.h"
+#include "map.h"
 
 using namespace std;
 
@@ -78,7 +79,8 @@ int main(int argc, char *args[])
             printf("Window could not be created! SDL_Error: %s\n",
                    SDL_GetError());
         } else {
-            Game game;
+            Map default_map(g_map);
+            Game game(&default_map);
             RayCasterFloat floatCaster;
             Renderer floatRenderer(&floatCaster);
             uint32_t floatBuffer[SCREEN_WIDTH * SCREEN_HEIGHT];

--- a/map.cpp
+++ b/map.cpp
@@ -1,0 +1,11 @@
+#include "map.h"
+#include "raycaster_data.h"
+
+bool Map::IsWall(uint8_t tileX, uint8_t tileY) const
+{
+    if (tileX > MAP_X - 1 || tileY > MAP_Y - 1) {
+        return true;
+    }
+    return LOOKUP8(mapData, (tileX >> 3) + (tileY << (MAP_XS - 3))) &
+           (1 << (8 - (tileX & 0x7)));
+}

--- a/map.h
+++ b/map.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
-#define MAP_X (uint8_t) 32
-#define MAP_XS (uint8_t) 5
-#define MAP_Y (uint8_t) 32
+#define MAP_X 32
+#define MAP_XS 5
+#define MAP_Y 32
 
 class Map
 {

--- a/map.h
+++ b/map.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include "raycaster_data.h"
+
+#define MAP_X (uint8_t) 32
+#define MAP_XS (uint8_t) 5
+#define MAP_Y (uint8_t) 32
+
+class Map
+{
+public:
+    Map(const uint8_t *mapData) : mapData(mapData) {}
+    inline bool IsWall(uint8_t tileX, uint8_t tileY) const
+    {
+        if (tileX > MAP_X - 1 || tileY > MAP_Y - 1) {
+            return true;
+        }
+        return LOOKUP8(mapData, (tileX >> 3) + (tileY << (MAP_XS - 3))) &
+               (1 << (8 - (tileX & 0x7)));
+    }
+
+    ~Map(){};
+
+private:
+    const uint8_t *mapData;
+};

--- a/map.h
+++ b/map.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include "raycaster_data.h"
 
 #define MAP_X (uint8_t) 32
 #define MAP_XS (uint8_t) 5
@@ -11,14 +10,7 @@ class Map
 {
 public:
     Map(const uint8_t *mapData) : mapData(mapData) {}
-    inline bool IsWall(uint8_t tileX, uint8_t tileY) const
-    {
-        if (tileX > MAP_X - 1 || tileY > MAP_Y - 1) {
-            return true;
-        }
-        return LOOKUP8(mapData, (tileX >> 3) + (tileY << (MAP_XS - 3))) &
-               (1 << (8 - (tileX & 0x7)));
-    }
+    bool IsWall(uint8_t tileX, uint8_t tileY) const;
 
     ~Map(){};
 

--- a/raycaster.h
+++ b/raycaster.h
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 
+#include "map.h"
+
 /* specify the precalcuated tables */
 #define TABLES_320
 
@@ -10,13 +12,7 @@
 #define SCREEN_SCALE 2
 #define FOV (double) (M_PI / 2)
 #define INV_FACTOR (float) (SCREEN_WIDTH * 95.0f / 320.0f)
-#define LOOKUP_TBL
-#define LOOKUP8(tbl, offset) tbl[offset]
-#define LOOKUP16(tbl, offset) tbl[offset]
 
-#define MAP_X (uint8_t) 32
-#define MAP_XS (uint8_t) 5
-#define MAP_Y (uint8_t) 32
 #define INV_FACTOR_INT ((uint16_t)(SCREEN_WIDTH * 75))
 #define MIN_DIST (int) ((150 * ((float) SCREEN_WIDTH / (float) SCREEN_HEIGHT)))
 #define HORIZON_HEIGHT (SCREEN_HEIGHT / 2)
@@ -26,7 +22,10 @@
 class RayCaster
 {
 public:
-    virtual void Start(uint16_t playerX, uint16_t playerY, int16_t playerA) = 0;
+    virtual void Start(uint16_t playerX,
+                       uint16_t playerY,
+                       int16_t playerA,
+                       Map *m) = 0;
 
     virtual void Trace(uint16_t screenX,
                        uint8_t *screenY,
@@ -38,4 +37,7 @@ public:
     RayCaster(){};
 
     ~RayCaster(){};
+
+protected:
+    Map *map;
 };

--- a/raycaster_data.h
+++ b/raycaster_data.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#define LOOKUP_TBL
+#define LOOKUP8(tbl, offset) tbl[offset]
+#define LOOKUP16(tbl, offset) tbl[offset]
+
 const uint8_t LOOKUP_TBL g_map[] = {
     0b00000000, 0b10000000, 0b00000000, 0b00000000, 0b01111010, 0b10111111,
     0b11111111, 0b00000000, 0b00111000, 0b10100000, 0b00001000, 0b01001100,

--- a/raycaster_fixed.cpp
+++ b/raycaster_fixed.cpp
@@ -58,15 +58,6 @@ inline int16_t RayCasterFixed::AbsTan(uint8_t quarter,
     return LOOKUP16(lookupTable, angle);
 }
 
-inline bool RayCasterFixed::IsWall(uint8_t tileX, uint8_t tileY)
-{
-    if (tileX > MAP_X - 1 || tileY > MAP_Y - 1) {
-        return true;
-    }
-    return LOOKUP8(g_map, (tileX >> 3) + (tileY << (MAP_XS - 3))) &
-           (1 << (8 - (tileX & 0x7)));
-}
-
 void RayCasterFixed::LookupHeight(uint16_t distance,
                                   uint8_t *height,
                                   uint16_t *step)
@@ -118,7 +109,7 @@ void RayCasterFixed::CalculateDistance(uint16_t rayX,
             }
             for (;;) {
                 tileY += tileStepY;
-                if (IsWall(tileX, tileY)) {
+                if (map->IsWall(tileX, tileY)) {
                     goto HorizontalHit;
                 }
             }
@@ -131,7 +122,7 @@ void RayCasterFixed::CalculateDistance(uint16_t rayX,
             }
             for (;;) {
                 tileX += tileStepX;
-                if (IsWall(tileX, tileY)) {
+                if (map->IsWall(tileX, tileY)) {
                     goto VerticalHit;
                 }
             }
@@ -177,7 +168,7 @@ void RayCasterFixed::CalculateDistance(uint16_t rayX,
             while ((tileStepY == 1 && (interceptY >> 8 < tileY)) ||
                    (tileStepY == -1 && (interceptY >> 8 >= tileY))) {
                 tileX += tileStepX;
-                if (IsWall(tileX, tileY)) {
+                if (map->IsWall(tileX, tileY)) {
                     goto VerticalHit;
                 }
                 interceptY += stepY;
@@ -185,7 +176,7 @@ void RayCasterFixed::CalculateDistance(uint16_t rayX,
             while ((tileStepX == 1 && (interceptX >> 8 < tileX)) ||
                    (tileStepX == -1 && (interceptX >> 8 >= tileX))) {
                 tileY += tileStepY;
-                if (IsWall(tileX, tileY)) {
+                if (map->IsWall(tileX, tileY)) {
                     goto HorizontalHit;
                 }
                 interceptX += stepX;
@@ -293,15 +284,23 @@ void RayCasterFixed::Trace(uint16_t screenX,
     }
 }
 
-void RayCasterFixed::Start(uint16_t playerX, uint16_t playerY, int16_t playerA)
+void RayCasterFixed::Start(uint16_t playerX,
+                           uint16_t playerY,
+                           int16_t playerA,
+                           Map *m)
 {
     _viewQuarter = playerA >> 8;
     _viewAngle = playerA % 256;
     _playerX = playerX;
     _playerY = playerY;
     _playerA = playerA;
+    map = m;
 }
 
-RayCasterFixed::RayCasterFixed() : RayCaster() {}
+RayCasterFixed::RayCasterFixed() : RayCaster()
+{
+}
 
-RayCasterFixed::~RayCasterFixed() {}
+RayCasterFixed::~RayCasterFixed()
+{
+}

--- a/raycaster_fixed.cpp
+++ b/raycaster_fixed.cpp
@@ -297,10 +297,6 @@ void RayCasterFixed::Start(uint16_t playerX,
     map = m;
 }
 
-RayCasterFixed::RayCasterFixed() : RayCaster()
-{
-}
+RayCasterFixed::RayCasterFixed() : RayCaster() {}
 
-RayCasterFixed::~RayCasterFixed()
-{
-}
+RayCasterFixed::~RayCasterFixed() {}

--- a/raycaster_fixed.h
+++ b/raycaster_fixed.h
@@ -4,7 +4,7 @@
 class RayCasterFixed : public RayCaster
 {
 public:
-    void Start(uint16_t playerX, uint16_t playerY, int16_t playerA);
+    void Start(uint16_t playerX, uint16_t playerY, int16_t playerA, Map *map);
     void Trace(uint16_t screenX,
                uint8_t *screenY,
                uint8_t *textureNo,
@@ -22,17 +22,16 @@ private:
     uint8_t _viewQuarter;
     uint8_t _viewAngle;
 
-    static void CalculateDistance(uint16_t rayX,
-                                  uint16_t rayY,
-                                  uint16_t rayA,
-                                  int16_t *deltaX,
-                                  int16_t *deltaY,
-                                  uint8_t *textureNo,
-                                  uint8_t *textureX);
+    void CalculateDistance(uint16_t rayX,
+                           uint16_t rayY,
+                           uint16_t rayA,
+                           int16_t *deltaX,
+                           int16_t *deltaY,
+                           uint8_t *textureNo,
+                           uint8_t *textureX);
     static void LookupHeight(uint16_t distance,
                              uint8_t *height,
                              uint16_t *step);
-    static bool IsWall(uint8_t tileX, uint8_t tileY);
     static int16_t MulTan(uint8_t value,
                           bool inverse,
                           uint8_t quarter,

--- a/raycaster_float.cpp
+++ b/raycaster_float.cpp
@@ -3,22 +3,6 @@
 #include "raycaster_float.h"
 #include <math.h>
 
-bool RayCasterFloat::IsWall(float rayX, float rayY)
-{
-    float mapX = 0;
-    float mapY = 0;
-    float offsetX = modff(rayX, &mapX);
-    float offsetY = modff(rayY, &mapY);
-    int tileX = static_cast<int>(mapX);
-    int tileY = static_cast<int>(mapY);
-
-    if (tileX < 0 || tileY < 0 || tileX >= MAP_X - 1 || tileY >= MAP_Y - 1) {
-        return true;
-    }
-    return g_map[(tileX >> 3) + (tileY << (MAP_XS - 3))] &
-           (1 << (8 - (tileX & 0x7)));
-}
-
 float RayCasterFloat::Distance(float playerX,
                                float playerY,
                                float rayA,
@@ -93,7 +77,7 @@ float RayCasterFloat::Distance(float playerX,
                 (tileStepY == -1 && (interceptY >= tileY)))) {
             somethingDone = true;
             tileX += tileStepX;
-            if (IsWall(tileX, interceptY)) {
+            if (map->IsWall(tileX, interceptY)) {
                 verticalHit = true;
                 rayX = tileX + (tileStepX == -1 ? 1 : 0);
                 rayY = interceptY;
@@ -107,7 +91,7 @@ float RayCasterFloat::Distance(float playerX,
                                 (tileStepX == -1 && (interceptX >= tileX)))) {
             somethingDone = true;
             tileY += tileStepY;
-            if (IsWall(interceptX, tileY)) {
+            if (map->IsWall(interceptX, tileY)) {
                 horizontalHit = true;
                 rayX = interceptX;
                 *hitOffset = interceptX;
@@ -162,13 +146,21 @@ void RayCasterFloat::Trace(uint16_t screenX,
     }
 }
 
-void RayCasterFloat::Start(uint16_t playerX, uint16_t playerY, int16_t playerA)
+void RayCasterFloat::Start(uint16_t playerX,
+                           uint16_t playerY,
+                           int16_t playerA,
+                           Map *m)
 {
     _playerX = (playerX / 1024.0f) * 4.0f;
     _playerY = (playerY / 1024.0f) * 4.0f;
     _playerA = (playerA / 1024.0f) * 2.0f * M_PI;
+    map = m;
 }
 
-RayCasterFloat::RayCasterFloat() : RayCaster() {}
+RayCasterFloat::RayCasterFloat() : RayCaster()
+{
+}
 
-RayCasterFloat::~RayCasterFloat() {}
+RayCasterFloat::~RayCasterFloat()
+{
+}

--- a/raycaster_float.cpp
+++ b/raycaster_float.cpp
@@ -157,10 +157,6 @@ void RayCasterFloat::Start(uint16_t playerX,
     map = m;
 }
 
-RayCasterFloat::RayCasterFloat() : RayCaster()
-{
-}
+RayCasterFloat::RayCasterFloat() : RayCaster() {}
 
-RayCasterFloat::~RayCasterFloat()
-{
-}
+RayCasterFloat::~RayCasterFloat() {}

--- a/raycaster_float.h
+++ b/raycaster_float.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "raycaster.h"
-#include "raycaster_data.h"
 
 class RayCasterFloat : public RayCaster
 {

--- a/raycaster_float.h
+++ b/raycaster_float.h
@@ -5,7 +5,7 @@
 class RayCasterFloat : public RayCaster
 {
 public:
-    void Start(uint16_t playerX, uint16_t playerY, int16_t playerA);
+    void Start(uint16_t playerX, uint16_t playerY, int16_t playerA, Map *map);
     void Trace(uint16_t screenX,
                uint8_t *screenY,
                uint8_t *textureNo,
@@ -26,5 +26,4 @@ private:
                    float rayA,
                    float *hitOffset,
                    int *hitDirection);
-    bool IsWall(float rayX, float rayY);
 };

--- a/renderer.cpp
+++ b/renderer.cpp
@@ -7,7 +7,7 @@ void Renderer::TraceFrame(Game *g, uint32_t *fb)
     _rc->Start(static_cast<uint16_t>(g->playerX * 256.0f),
                static_cast<uint16_t>(g->playerY * 256.0f),
                static_cast<int16_t>(g->playerA / (2.0f * M_PI) * 1024.0f),
-               g->map);
+               &g->map);
 
     for (int x = 0; x < SCREEN_WIDTH; x++) {
         uint8_t sso;

--- a/renderer.cpp
+++ b/renderer.cpp
@@ -6,7 +6,8 @@ void Renderer::TraceFrame(Game *g, uint32_t *fb)
 {
     _rc->Start(static_cast<uint16_t>(g->playerX * 256.0f),
                static_cast<uint16_t>(g->playerY * 256.0f),
-               static_cast<int16_t>(g->playerA / (2.0f * M_PI) * 1024.0f));
+               static_cast<int16_t>(g->playerA / (2.0f * M_PI) * 1024.0f),
+               g->map);
 
     for (int x = 0; x < SCREEN_WIDTH; x++) {
         uint8_t sso;


### PR DESCRIPTION
+ The refactor in #3  was not good enough, so I came up with another one. In this new refactor, raycaster only needs
a reference to the Map object instead of the whole `Game` object. This still allows `Game` to use `IsWall()` from Map object, which can be used to implement wall collision. 
+ Wrapping the map in a class also enable possible feature like switching map in the future.
+ some macro in `raycaster.h` are moved to other places to avoid circular include.