### PR TITLE
Fix wrong positions of certain boundary walls

### DIFF
--- a/raycaster_fixed.cpp
+++ b/raycaster_fixed.cpp
@@ -60,7 +60,7 @@ inline int16_t RayCasterFixed::AbsTan(uint8_t quarter,
 
 inline bool RayCasterFixed::IsWall(uint8_t tileX, uint8_t tileY)
 {
-    if (tileX > MAP_X - 1 || tileY > MAP_Y - 1) {
+    if (tileX >= MAP_X - 1 || tileY >= MAP_Y - 1) {
         return true;
     }
     return LOOKUP8(g_map, (tileX >> 3) + (tileY << (MAP_XS - 3))) &


### PR DESCRIPTION
As a result, IsWall() is modified.
Because the conditions of MAP_X and MAP_Y were wrong, I change them
from > to >=.