### PR TITLE
Fix build by defining missing math constants

### DIFF
--- a/tools/precalculator.c
+++ b/tools/precalculator.c
@@ -4,6 +4,15 @@
 
 #include "raycaster.h"
 
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef M_PI_2
+#define M_PI_2 1.57079632679489661923
+#endif
+
 static uint16_t g_tan[256];
 static uint16_t g_cotan[256];
 static uint8_t g_sin[256];


### PR DESCRIPTION
Provide definitions for PI and PI2 when they are not present in math.h. This fixes build failures under strict ISO C modes.